### PR TITLE
Added support for testing custom awesomewm builds

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ AwesomeWM Testing Tool requires Xephyr, an Xorg-Application which can spawn a ne
 Here's an example of what it looks like: https://github.com/mikar/awmtt/blob/master/example.jpg
 
 awmtt [ start | stop | restart | -h | -e | -t [ get | change | list | random ]]
-[ -C /path/to/rc.lua ] [ -D display ] [ -S windowsize ] [-o 'additional args to pass to awesome' ]
+[ -C /path/to/rc.lua ] [ -A /path/to/awesome ] [ -D display ] [ -S windowsize ] [-o 'additional args to pass to awesome' ]
 
   start			Spawn nested Awesome via Xephyr
   stop			Stops Xephyr
@@ -12,6 +12,7 @@ awmtt [ start | stop | restart | -h | -e | -t [ get | change | list | random ]]
   restart		Restart nested Awesome
   -N|--notest		Don't use a testfile but your actual rc.lua (i.e. $HOME/.config/awesome/rc.lua)
   -C|--config		Specify configuration file
+  -A|--awmbin       Specify Awesome binary (for testing custom awesome builds)
   -D|--display		Specify the display to use (e.g. 1)
   -S|--size		Specify the window size
   -e|--execute		Execute command in nested Awesome
@@ -27,6 +28,7 @@ examples:
 awmtt start (uses defaults)
 awmtt start -D 3 -C /etc/xdg/awesome/rc.lua -S 1280x800
 awmtt -t change zenburn
+awmtt start -A /home/gitforks/awesome/awesome
 
 The defaults are -D 1 -C $HOME/.config/awesome/rc.lua.test -S 1024x640.
 

--- a/README
+++ b/README
@@ -12,7 +12,7 @@ awmtt [ start | stop | restart | -h | -e | -t [ get | change | list | random ]]
   restart		Restart nested Awesome
   -N|--notest		Don't use a testfile but your actual rc.lua (i.e. $HOME/.config/awesome/rc.lua)
   -C|--config		Specify configuration file
-  -A|--awmbin       Specify Awesome binary (for testing custom awesome builds)
+  -A|--awmbin		Specify Awesome binary (for testing custom awesome builds)
   -D|--display		Specify the display to use (e.g. 1)
   -S|--size		Specify the window size
   -e|--execute		Execute command in nested Awesome

--- a/awmtt
+++ b/awmtt
@@ -6,7 +6,7 @@
 usage() {
   cat <<EOF
 awmtt [ start | stop | restart | -h | -e | -t [ get | change | list | random ]]
-[ -C /path/to/rc.lua ] [ -D display ] [ -S windowsize ] [-o 'additional args to pass to awesome' ]
+[ -C /path/to/rc.lua ] [ -A /path/to/awesome ] [ -D display ] [ -S windowsize ] [-o 'additional args to pass to awesome' ]
 
   start         Spawn nested Awesome via Xephyr
   stop          Stops Xephyr
@@ -14,6 +14,7 @@ awmtt [ start | stop | restart | -h | -e | -t [ get | change | list | random ]]
   restart       Restart nested Awesome
   -N|--notest       Don't use a testfile but your actual rc.lua (i.e. $HOME/.config/awesome/rc.lua)
   -C|--config       Specify configuration file
+  -A|--awmbin       Specify Awesome binary (for testing custom awesome builds)
   -D|--display      Specify the display to use (e.g. 1)
   -S|--size     Specify the window size
   -e|--execute      Execute command in nested Awesome
@@ -197,6 +198,7 @@ parse_options() {
     case "$1" in
         -N|--notest)    RC_FILE="$HOME"/.config/awesome/rc.lua ;;
         -C|--config)    shift; RC_FILE="$1" ;;
+        -A|--awmbin)    shift; AWESOME="$1" ;;
         -D|--display)   shift; D="$1"
                 [[ ! "$D" =~ ^[0-9] ]] && errorout "$D is not a valid display number" ;;
         -S|--size)      shift; SIZE="$1" ;;

--- a/awmtt
+++ b/awmtt
@@ -40,7 +40,7 @@ EOF
 #}}}
 
 #{{{ Utilities
-awesome_pid() { pgrep -fn "/usr/bin/awesome"; }
+awesome_pid() { pgrep -n "awesome"; }
 xephyr_pid() { pgrep -f xephyr_$D; }
 errorout() { echo "error: $*" >&2; exit 1; }
 #}}}

--- a/awmtt
+++ b/awmtt
@@ -108,7 +108,7 @@ stop() {
 #{{{ Restart function
 restart() { # TODO: (maybe use /tmp/.X{i}-lock files) Find a way to uniquely identify an awesome instance (without storing the PID in a file). Until then all instances spawned by this script are restarted...
     echo -n "Restarting Awesome... "
-    for i in $(pgrep -f "/usr/bin/awesome -c"); do kill -s SIGHUP $i; done
+    for i in $(pgrep -f "awesome -c"); do kill -s SIGHUP $i; done
 }
 #}}}
 #{{{ Run function


### PR DESCRIPTION
These commits address issue/discussion #5.

User's can now specify an awesome binary outside of the system path, for example:

`awmtt -A /home/iorbitearth/repos/awesome/awesome start`

This would be of use to developers interested in contributing/tweaking the awesome source code and testing their changes in an isolated X session.

A few of the commits here address the `awesome_pid()` and `restart()` functions in order to support the new -A option (`pgrep` now needs to account for awesome processes that didn't originate from `/usr/bin/awesome`).

If this seems useful to others, it may be worth incrementing the version and resubmitting the PKGBUILD to the AUR. Thanks!