### PR TITLE
Fix detection of free DISPLAYs

### DIFF
--- a/awmtt.sh
+++ b/awmtt.sh
@@ -80,7 +80,7 @@ HOSTNAME=$(uname -n)
 start() {
     # check for free $DISPLAYs
     for ((i=0;;i++)); do
-        if [[ ! -f "/tmp/.X${i}-lock" ]]; then
+        if [[ ! -f "/tmp/.X11-unix/X${i}" ]]; then
             D=$i;
             break;
         fi;


### PR DESCRIPTION
The file `/tmp/.X0-lock` doesn't exist even though I have a display 0.
However the file `/tmp/.X11-unix/X0` exists instead.